### PR TITLE
[12] babel-polyfill - error Error: only one instance of babel-polyfill is allowed

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-node": "^9.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.0",
+    "idempotent-babel-polyfill": "^7.4.4",
     "node-sass": "^4.12.0",
     "optimist": "^0.6.1",
     "sass-loader": "^7.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,11 @@
-const path = require('path')
-const args = require('optimist').argv
-const VueLoaderPlugin = require('vue-loader/lib/plugin')
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
+const path = require('path');
+const args = require('optimist').argv;
+const VueLoaderPlugin = require('vue-loader/lib/plugin');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 module.exports = {
   mode: args.mode,
-  entry: ['babel-polyfill', './src/index.js'],
+  entry: ['idempotent-babel-polyfill', './src/index.js'],
   output: {
     filename: 'index.js',
     path: path.join(__dirname, 'dist'),
@@ -69,8 +69,8 @@ module.exports = {
   plugins: [
     new VueLoaderPlugin()
   ]
-}
+};
 
 if (process.env.ANALYZE) {
-  module.exports.plugins.push(new BundleAnalyzerPlugin())
+  module.exports.plugins.push(new BundleAnalyzerPlugin());
 }


### PR DESCRIPTION
**Description**
The ``vue-facebook-login-component`` installed via npm can throws an error when root app project also imports ``babel-polyfill``. To fix this I had to remove the ``babel-polyfill`` from the entry in webpack.config and add ``idempotent-babel-polyfill`` (which checks if requiring ``babel-polyfill`` is needed or not). That makes it work without throwing any error and breaking app. 

**Issue link** 
https://github.com/adi518/vue-facebook-login-component/issues/12