### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # Vue Facebook Login
 
-> A renderless Vue.js component for composing Facebook login.
+> A render less Vue.js component for composing Facebook login.
 
 ## [Install](#install)
 
 ### NPM
 
 ```console
-npm install vue-facebook-login-component
+npm install view-Facebook-login-component
 ```
 
 ### Yarn
 
 ```console
-yarn add vue-facebook-login-component
+yarn add view-Facebook-login-component
 ```
 
 ### Embed Directly
@@ -135,7 +135,7 @@ Offering an alternative logo from [Iconmonstr](https://iconmonstr.com/facebook-1
 | working | `'Please wait...'`                                              |
 | logo    | [Iconmonstr Facebook 6](https://iconmonstr.com/facebook-6-svg/) | See [Iconmonstr](https://iconmonstr.com/?s=facebook) for more options. |
 | before  | `NONE`                                                          | Before all nested elements.                                            |
-| after   | `NONE`                                                          | After all nested elements.                                             |
+| after   | `NONE`                                                          | After all, nested elements.                                             |
 | error   | `'⛔ Error'`                                                    | Shown on error (e.g., SDK load failure).                               |
 
 </div>
@@ -192,7 +192,7 @@ You can use this event to grab the Facebook SDK instance, but **also** the under
 
 ## [Scope Component (Advanced Customization)](#scope-component-advanced-customization)
 
-If props, slots and events do not provide enough customization, you can use an underlying component called `v-fb-login-scope`. This component uses the render prop (known as "scoped-slot" in Vue) approach for composition. This means, it does not render **any** HTML or CSS, but rather expose a scoped-slot with attributes and methods that are committed as API. [Read more](https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots) about scoped slots.
+If props, slots, and events do not provide enough customization, you can use an underlying component called `v-Fb-login-scope`. This component uses the render prop (known as "scoped-slot" in Vue) approach for composition. This means, it does not render **any** HTML or CSS, but rather expose a scoped-slot with attributes and methods that are committed as API. [Read more](https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots) about scoped slots.
 
 ### Props and Events
 
@@ -206,7 +206,7 @@ Refer to the [tables](#props) above for scope component **specific** props/event
 | ------------ | -------- | ------------------------------------------ |
 | login        | Function | Call SDK login method.                     |
 | logout       | Function | Call SDK logout method.                    |
-| toggleLogin  | Function | Toggle SDK login/logout methods.           |
+| toggle logic  | Function | Toggle SDK login/logout methods.           |
 | working      | Boolean  | Asynchronous operation is taking place.    |
 | idle         | Boolean  | No asynchronous operation is taking place. |
 | connected    | Boolean  | User is logged in.                         |
@@ -243,13 +243,13 @@ The following snippet is a minimal usage example, see [source](https://github.co
 
 ## [Loading Facebook SDK](#loading-facebook-sdk)
 
-This component embeds the [Facebook SDK snippet](https://developers.facebook.com/docs/javascript/quickstart/) unless it find an existing SDK instance. However, be sure to resolve `window.fbAsyncInit` **before** a component instance is created, otherwise a racing condition will occur and it may not be able to find the SDK instance. See [Facebook docs](https://developers.facebook.com/docs/javascript/quickstart/) for more.
+This component embeds the [Facebook SDK snippet](https://developers.facebook.com/docs/javascript/quickstart/) unless it finds an existing SDK instance. However, be sure to resolve `window.fbAsyncInit` **before** a component instance is created, otherwise, a racing condition will occur and it may not be able to find the SDK instance. See [Facebook docs](https://developers.facebook.com/docs/javascript/quickstart/) for more.
 
 ## [Legacy Browser Support](#ie-support)
 
 > ❤️ You probably don't need to apply transformations or polyfills to support IE.
 
-The current build statistically targets legacy browsers like IE 11 and applies transforms and polyfills adaptively. However, it is bound to change in the future as statistics change. In such case, you'll need to add [@babel/polyfill](https://babeljs.io/docs/en/babel-polyfill) to your dependencies (notice the deprecated way to do it and the newly recommended one). Additionally, you'll have to add this component to your transpiled dependencies (e.g., using `transpileDependencies` option in [`vue.config.js`](https://cli.vuejs.org/config/#transpiledependencies)).
+The current build statistically targets legacy browsers like IE 11 and applies transforms and polyfills adaptively. However, it is bound to change in the future as statistics change. In such a case, you'll need to add [@babel/polyfill](https://babeljs.io/docs/en/babel-polyfill) to your dependencies (notice the deprecated way to do it and the newly recommended one). Additionally, you'll have to add this component to your transpile dependencies (e.g., using the `transpileDependencies` option in [`vue.config.js`](https://cli.vuejs.org/config/#transpiledependencies)).
 
 > ⚠️ Notice the difference between a transform and a polyfill. Future syntax has to be transformed, while new language API requires a polyfill.
 
@@ -257,11 +257,11 @@ The current build statistically targets legacy browsers like IE 11 and applies t
 
 > 💚 TL;DR: Upgrade to `2.x` to support legacy browsers.
 
-Versions `<=1.3.6` should work in legacy browsers without issues. Versions `1.3.7-1.5.0` require `@babel/polyfill` if your app doesn't already include it. Versions `1.5.1` to `1.6.0` have a maltransformed and unpolyfilled build that will not work with legacy browsers unless you add it to your transpiled dependencies and import `@babel/polyfill`. To fix that please upgrade to `2.x` (recommended) or downgrade to `<= 1.5.0`.
+Versions `<=1.3.6` should work in legacy browsers without issues. Versions `1.3.7-1.5.0` require `@babel/polyfill` if your app doesn't already include it. Versions `1.5.1` to `1.6.0` has a man transformed and unfulfilled build that will not work with legacy browsers unless you add it to your transpile dependencies and import `@babel/polyfill`. To fix that please upgrade to `2.x` (recommended) or downgrade to `<= 1.5.0`.
 
 ## [Development](#development)
 
-Fork, clone and use the following scripts.
+Fork, clone, and use the following scripts.
 
 ### Component
 
@@ -272,7 +272,7 @@ yarn start
 ### Documentation
 
 ```console
-yarn start:docs
+yarn start: docs
 ```
 
 ### Tests
@@ -287,7 +287,7 @@ Please search existing issues (including closed ones) before starting a new [iss
 
 ## Contributing
 
-Start a pull request, run tests and update as necessary before submitting.
+Start a pull request, run tests, and update as necessary before submitting.
 
 ## [Related Links](#related-links)
 


### PR DESCRIPTION
> A renderless Vue.js component for composing Facebook login. => A render less Vue.js component for composing Facebook login.
npm install vue-facebook-login-component = npm install view-Facebook-login-component
| toggleLogin  |  =| toggle logic 
include it. Versions `1.5.1` to `1.6.0` have a maltransformed =include it. Versions `1.5.1` to `1.6.0` have a man transformed